### PR TITLE
Remove password_hash column from User model (handled by Supabase Auth)

### DIFF
--- a/Backend/app/models/models.py
+++ b/Backend/app/models/models.py
@@ -27,7 +27,6 @@ class User(Base):
     id = Column(String, primary_key=True, default=generate_uuid)
     username = Column(String, unique=True, nullable=False)
     email = Column(String, unique=True, nullable=False)
-    password_hash = Column(Text, nullable=False)
     role = Column(String, nullable=False)  # 'creator' or 'brand'
     profile_image = Column(Text, nullable=True)
     bio = Column(Text, nullable=True)


### PR DESCRIPTION


## 📝 Description

This pull request removes the `password_hash` column from the `User` SQLAlchemy model and, consequently, from the `users` table in the database.  
Since authentication is handled by Supabase Auth, storing password hashes in the application's own user table is unnecessary and  caused conflicts and confusion.

## 🔧 Changes Made

- Removed the `password_hash` column from the `User` model in `Backend/app/models/models.py`.
- Updated the model so that new databases/tables will not include this column.


## 📷 Screenshots or Visual Changes (if applicable)

N/A – This is a backend-only change with no visual impact.



