### PR TITLE
Remove password_hash from users model, schema, and route (cuz it is managed by supabase auth)

### DIFF
--- a/Backend/app/models/models.py
+++ b/Backend/app/models/models.py
@@ -27,7 +27,6 @@ class User(Base):
     id = Column(String, primary_key=True, default=generate_uuid)
     username = Column(String, unique=True, nullable=False)
     email = Column(String, unique=True, nullable=False)
-    password_hash = Column(Text, nullable=False)
     role = Column(String, nullable=False)  # 'creator' or 'brand'
     profile_image = Column(Text, nullable=True)
     bio = Column(Text, nullable=True)

--- a/Backend/app/routes/post.py
+++ b/Backend/app/routes/post.py
@@ -44,7 +44,6 @@ async def create_user(user: UserCreate):
         "id": user_id,
         "username": user.username,
         "email": user.email,
-        "password_hash": user.password_hash,  
         "role": user.role,
         "profile_image": user.profile_image,
         "bio": user.bio,

--- a/Backend/app/schemas/schema.py
+++ b/Backend/app/schemas/schema.py
@@ -5,7 +5,7 @@ from datetime import datetime
 class UserCreate(BaseModel):
     username: str
     email: str
-    password_hash: str
+    # password_hash: str  # Removed: managed by Supabase Auth
     role: str
     profile_image: Optional[str] = None
     bio: Optional[str] = None


### PR DESCRIPTION
Here’s a complete PR description you can use for your `remove-password-hash` branch, including the SQL migration:

## 📝 Description

This pull request removes the `password_hash` column from the public `users` table in both the backend code and the database schema. Passwords are securely managed by Supabase Auth in its private `auth.users` table, so storing a password hash in the public profile table is unnecessary and could be a security risk. 

## 🔧 Changes Made

- Removed the `password_hash` field from the SQLAlchemy `User` model.
- Removed the `password_hash` field from the Pydantic `UserCreate` schema.
- Removed the `password_hash` field from the `/users/` creation route.
- Updated all relevant code to no longer reference or insert `password_hash`.
- **Added SQL migration instructions** to drop the column from the database.



## 🛠️ SQL Migration

To remove the `password_hash` column from your existing database, run the following SQL in your Supabase SQL editor or psql:

```sql
ALTER TABLE public.users DROP COLUMN IF EXISTS password_hash;
```


### ✅ Checklist

- [✅ ] I have read the contributing guidelines.

