### PR TITLE
FEAT(types): add proposals analytics types

### DIFF
--- a/frontend/types/analytics.ts
+++ b/frontend/types/analytics.ts
@@ -1,0 +1,135 @@
+/**
+ * Campaign Analytics & ROI Tracking Types
+ */
+
+export interface CampaignDeliverableMetric {
+  id: string;
+  campaign_deliverable_id: string;
+  name: string;
+  display_name?: string;
+  target_value?: number;
+  is_custom: boolean;
+  created_at: string;
+  latest_update?: MetricUpdate;
+  latest_feedback?: MetricFeedback;
+  pending_requests?: UpdateRequest[];
+}
+
+export interface MetricUpdate {
+  id: string;
+  campaign_deliverable_metric_id: string;
+  value: number;
+  demographics?: Record<string, any>;
+  screenshot_url?: string;
+  ai_extracted_data?: Record<string, any>;
+  submitted_by: string;
+  submitted_at: string;
+}
+
+export interface MetricFeedback {
+  id: string;
+  metric_update_id: string;
+  brand_id: string;
+  feedback_text: string;
+  created_at: string;
+}
+
+export interface UpdateRequest {
+  id: string;
+  campaign_deliverable_metric_id?: string;
+  brand_id: string;
+  creator_id: string;
+  requested_at: string;
+  status: "pending" | "completed" | "cancelled";
+  campaign_deliverable_metrics?: {
+    name: string;
+    display_name?: string;
+    campaign_deliverable_id: string;
+    campaign_deliverables?: {
+      platform: string;
+      content_type: string;
+      campaign_id: string;
+      campaigns?: {
+        title: string;
+      };
+    };
+  };
+}
+
+export interface DeliverableWithMetrics {
+  id: string;
+  platform: string;
+  content_type: string;
+  quantity: number;
+  guidance?: string;
+  metrics: CampaignDeliverableMetric[];
+}
+
+export interface AnalyticsDashboard {
+  campaign_id: string;
+  campaign_title: string;
+  platforms: Array<{
+    platform: string;
+    deliverables: Array<{
+      id: string;
+      platform: string;
+      content_type: string;
+    }>;
+    metrics: CampaignDeliverableMetric[];
+  }>;
+  total_deliverables: number;
+  total_metrics: number;
+  metrics_with_updates: number;
+  overall_progress: number;
+}
+
+export interface MetricHistory {
+  audit_logs: Array<{
+    id: string;
+    campaign_deliverable_metric_id: string;
+    old_value?: number;
+    new_value?: number;
+    changed_by: string;
+    changed_at: string;
+    change_reason?: string;
+    profiles?: {
+      name: string;
+    };
+  }>;
+  updates: Array<MetricUpdate & {
+    profiles?: {
+      name: string;
+    };
+  }>;
+}
+
+export interface MetricCreateInput {
+  campaign_deliverable_id: string;
+  name: string;
+  display_name?: string;
+  target_value?: number;
+  is_custom?: boolean;
+}
+
+export interface MetricValueSubmitInput {
+  value: number;
+  demographics?: Record<string, any>;
+  screenshot_url?: string;
+  ai_extracted_data?: Record<string, any>;
+}
+
+export interface FeedbackCreateInput {
+  feedback_text: string;
+}
+
+export interface UpdateRequestCreateInput {
+  campaign_deliverable_metric_id?: string;
+  creator_id: string;
+}
+
+export interface ScreenshotExtractionResult {
+  extracted_data: Record<string, any>;
+  metric_name: string;
+  suggested_value?: number;
+}
+

--- a/frontend/types/proposals.ts
+++ b/frontend/types/proposals.ts
@@ -1,0 +1,118 @@
+export type NegotiationStatus = "none" | "open" | "finalized" | "declined";
+
+export type NegotiationEntryType =
+  | "message"
+  | "terms_update"
+  | "terms_proposal"
+  | "acceptance";
+
+export interface NegotiationEntry {
+  id: string;
+  sender_id: string;
+  sender_role: "Brand" | "Creator";
+  message: string;
+  timestamp: string;
+  type: NegotiationEntryType;
+  meta?: Record<string, any>;
+}
+
+export interface Proposal {
+  id: string;
+  campaign_id: string;
+  brand_id: string;
+  creator_id: string;
+  subject: string;
+  message: string;
+  proposed_amount: number | null;
+  content_ideas: string[] | null;
+  ideal_pricing: string | null;
+  status: string;
+  created_at: string;
+  updated_at: string;
+  campaign_title: string | null;
+  brand_name: string | null;
+  creator_name: string | null;
+  negotiation_status: NegotiationStatus;
+  negotiation_thread?: NegotiationEntry[];
+  current_terms?: Record<string, any>;
+  version?: number;
+  contract_id?: string | null;
+}
+
+export interface Contract {
+  id: string;
+  proposal_id: string;
+  brand_id: string;
+  creator_id: string;
+  terms: Record<string, any>;
+  status: string;
+  created_at: string;
+  updated_at: string;
+  brand_name: string | null;
+  creator_name: string | null;
+  proposal?: Proposal | null;
+  negotiation_thread?: NegotiationEntry[] | null;
+  unsigned_contract_link?: string | null;
+  signed_contract_link?: string | null;
+  unsigned_contract_downloaded_by_creator?: boolean;
+  signed_contract_downloaded_by_brand?: boolean;
+  pending_status_change?: {
+    requested_status: string;
+    requesting_party: "Brand" | "Creator";
+    requested_at: string;
+  } | null;
+}
+
+export interface AcceptNegotiationResponse {
+  proposal: Proposal;
+  contract: Contract;
+}
+
+export interface ContractChatMessage {
+  id: string;
+  contract_id: string;
+  sender_id: string;
+  sender_role: "Brand" | "Creator";
+  message: string;
+  created_at: string;
+}
+
+export interface Deliverable {
+  id: string;
+  contract_id: string;
+  description: string;
+  due_date: string | null;
+  status: "pending" | "under_review" | "rejected" | "completed";
+  submission_url: string | null;
+  review_comment: string | null;
+  rejection_reason: string | null;
+  brand_approval: boolean;
+  creator_approval: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface DeliverableCreate {
+  description: string;
+  due_date: string | null;
+}
+
+export interface ContractVersion {
+  id: string;
+  contract_id: string;
+  version_number: number;
+  file_url: string;
+  uploaded_by: string | null;
+  uploaded_at: string;
+  status: "pending" | "approved" | "rejected" | "final";
+  brand_approval: boolean;
+  creator_approval: boolean;
+  change_reason: string | null;
+  is_current: boolean;
+}
+
+export interface ContractVersionCreate {
+  file_url: string;
+  change_reason?: string | null;
+}
+


### PR DESCRIPTION
## 📝 Description

This pull request introduces new TypeScript types to support analytics for proposals. These types will help standardize data structures used in analytics features related to proposals, improving type safety and maintainability.

## 🔧 Changes Made

- Added new TypeScript types for proposals analytics.
- Updated related interfaces and type definitions.
- Refactored existing analytics code to use the new types.

### ✅ Checklist

- [ ] I have read the contributing guidelines.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if applicable).
- [ ] Any dependent changes have been merged and published in downstream modules.

