### PR TITLE
FEAT(pages): add proposals and analytics pages for brand and creator

### DIFF
--- a/frontend/app/brand/analytics/page.tsx
+++ b/frontend/app/brand/analytics/page.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import AuthGuard from "@/components/auth/AuthGuard";
+import SlidingMenu from "@/components/SlidingMenu";
+import BrandAnalyticsDashboard from "@/components/analytics/BrandAnalyticsDashboard";
+
+export default function BrandAnalyticsPage() {
+  return (
+    <AuthGuard requiredRole="Brand">
+      <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-purple-50">
+        <SlidingMenu role="brand" />
+        <main className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+          <BrandAnalyticsDashboard />
+        </main>
+      </div>
+    </AuthGuard>
+  );
+}

--- a/frontend/app/brand/proposals/page.tsx
+++ b/frontend/app/brand/proposals/page.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import AuthGuard from "@/components/auth/AuthGuard";
+import SlidingMenu from "@/components/SlidingMenu";
+import {
+  ProposalsWorkspace,
+  TabKey,
+} from "@/components/proposals/ProposalsWorkspace";
+import { useSearchParams } from "next/navigation";
+import { useMemo } from "react";
+
+export default function BrandProposalsPage() {
+  const searchParams = useSearchParams();
+
+  const initialTab = useMemo<TabKey>(() => {
+    const section = searchParams?.get("section")?.toLowerCase();
+    if (section === "negotiations") {
+      return section as TabKey;
+    }
+    return "proposals";
+  }, [searchParams]);
+
+  return (
+    <AuthGuard requiredRole="Brand">
+      <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-purple-50">
+        <SlidingMenu role="brand" />
+        <main className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+          <ProposalsWorkspace role="Brand" initialTab={initialTab} />
+        </main>
+      </div>
+    </AuthGuard>
+  );
+}

--- a/frontend/app/creator/analytics/[campaign_id]/page.tsx
+++ b/frontend/app/creator/analytics/[campaign_id]/page.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { use } from "react";
+import AuthGuard from "@/components/auth/AuthGuard";
+import SlidingMenu from "@/components/SlidingMenu";
+import CreatorCampaignDetailsView from "@/components/analytics/CreatorCampaignDetailsView";
+
+export default function CreatorCampaignDetailsPage({
+  params,
+}: {
+  params: Promise<{ campaign_id: string }>;
+}) {
+  const { campaign_id } = use(params);
+
+  return (
+    <AuthGuard requiredRole="Creator">
+      <div className="min-h-screen bg-gradient-to-br from-purple-50 via-white to-blue-50">
+        <SlidingMenu role="creator" />
+        <main className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+          <CreatorCampaignDetailsView campaignId={campaign_id} />
+        </main>
+      </div>
+    </AuthGuard>
+  );
+}
+

--- a/frontend/app/creator/analytics/page.tsx
+++ b/frontend/app/creator/analytics/page.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import AuthGuard from "@/components/auth/AuthGuard";
+import SlidingMenu from "@/components/SlidingMenu";
+import CreatorAnalyticsDashboard from "@/components/analytics/CreatorAnalyticsDashboard";
+
+export default function CreatorAnalyticsPage() {
+  return (
+    <AuthGuard requiredRole="Creator">
+      <div className="min-h-screen bg-gradient-to-br from-purple-50 via-white to-blue-50">
+        <SlidingMenu role="creator" />
+        <main className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+          <CreatorAnalyticsDashboard />
+        </main>
+      </div>
+    </AuthGuard>
+  );
+}

--- a/frontend/app/creator/proposals/page.tsx
+++ b/frontend/app/creator/proposals/page.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import AuthGuard from "@/components/auth/AuthGuard";
+import {
+  ProposalsWorkspace,
+  TabKey,
+} from "@/components/proposals/ProposalsWorkspace";
+import SlidingMenu from "@/components/SlidingMenu";
+import { useSearchParams } from "next/navigation";
+import { useEffect, useMemo, useRef, useState } from "react";
+
+export default function CreatorProposalsPage() {
+  const searchParams = useSearchParams();
+
+  const initialTab = useMemo<TabKey>(() => {
+    const section = searchParams?.get("section")?.toLowerCase();
+    if (section === "negotiations") {
+      return section as TabKey;
+    }
+    return "proposals";
+  }, [searchParams]);
+
+  // --- AI Review Progress Bar State ---
+  const [aiLoading, setAiLoading] = useState(false);
+  const [aiProgress, setAiProgress] = useState(0);
+  const [aiStatusIdx, setAiStatusIdx] = useState(0);
+  const aiStatusMessages = [
+    "Running initial checks...",
+    "Comparing with reference contracts...",
+    "Analyzing proposal structure...",
+    "Evaluating pricing fairness...",
+    "Checking for missing details...",
+    "Generating actionable feedback...",
+  ];
+  const aiIntervalRef = useRef<NodeJS.Timeout | null>(null);
+
+  // Simulate progress bar and rotating status messages (message every 3s, progress every 300ms)
+  useEffect(() => {
+    let progressInterval: NodeJS.Timeout | null = null;
+    if (aiLoading) {
+      setAiProgress(0);
+      setAiStatusIdx(0);
+      // Progress bar increments every 300ms
+      progressInterval = setInterval(() => {
+        setAiProgress((prev) => {
+          if (prev >= 100) return 100;
+          return prev + Math.floor(Math.random() * 5) + 2; // 2-6%
+        });
+      }, 300);
+      // Status message changes every 3 seconds
+      aiIntervalRef.current = setInterval(() => {
+        setAiStatusIdx((prev) => (prev + 1) % aiStatusMessages.length);
+      }, 3000);
+    } else {
+      setAiProgress(0);
+      setAiStatusIdx(0);
+      if (aiIntervalRef.current) clearInterval(aiIntervalRef.current);
+      if (progressInterval) clearInterval(progressInterval);
+    }
+    return () => {
+      if (aiIntervalRef.current) clearInterval(aiIntervalRef.current);
+      if (progressInterval) clearInterval(progressInterval);
+    };
+    // eslint-disable-next-line
+  }, [aiLoading]);
+
+  // Pass setAiLoading, aiLoading, aiProgress, aiStatusIdx, aiStatusMessages to ProposalsWorkspace or modal as needed
+
+  return (
+    <AuthGuard requiredRole="Creator">
+      <div className="min-h-screen bg-gradient-to-br from-purple-50 via-white to-blue-50">
+        <SlidingMenu role="creator" />
+        <main className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+          <ProposalsWorkspace
+            role="Creator"
+            initialTab={initialTab}
+            aiLoading={aiLoading}
+            setAiLoading={setAiLoading}
+            aiProgress={aiProgress}
+            aiStatusIdx={aiStatusIdx}
+            aiStatusMessages={aiStatusMessages}
+          />
+        </main>
+      </div>
+    </AuthGuard>
+  );
+}


### PR DESCRIPTION
## 📝 Description

This pull request introduces a new analytics page within the proposals section of the frontend. The analytics page provides users with visual insights and data summaries related to proposals, enhancing the overall user experience and decision-making process.

## 🔧 Changes Made

- Added a new analytics page under the proposals section.
## 🔧 Changes Made

- Added a new analytics page under the proposals section.
- Integrated charts and data visualizations for proposal metrics.
- Updated navigation to include the analytics page.
- Refactored proposal-related components for better reusability.
- Improved styling and responsiveness for analytics components.

### ✅ Checklist

- [ ] I have read the contributing guidelines.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if applicable).
- [ ] Any dependent changes have been merged and published in downstream modules.

