### PR TITLE
fix : correct modal order and prevent click-through on View Profile

### DIFF
--- a/Frontend/src/components/collaboration-hub/NewCollaborationModal.tsx
+++ b/Frontend/src/components/collaboration-hub/NewCollaborationModal.tsx
@@ -21,7 +21,11 @@ interface ProposalData {
   notes: string;
 }
 
-export default function NewCollaborationModal({ open, onClose, onSubmit }: NewCollaborationModalProps) {
+export default function NewCollaborationModal({
+  open,
+  onClose,
+  onSubmit,
+}: NewCollaborationModalProps) {
   const [modalStep, setModalStep] = useState(1);
   const [searchTerm, setSearchTerm] = useState("");
   const [selectedCreator, setSelectedCreator] = useState<any>(null);
@@ -33,7 +37,7 @@ export default function NewCollaborationModal({ open, onClose, onSubmit }: NewCo
     paymentSchedule: "",
     numberOfPosts: "",
     timeline: "",
-    notes: ""
+    notes: "",
   });
   const [aiProposal, setAiProposal] = useState<ProposalData | null>(null);
   const [reviewed, setReviewed] = useState(false);
@@ -43,7 +47,9 @@ export default function NewCollaborationModal({ open, onClose, onSubmit }: NewCo
 
   // Mock AI suggestions
   const handleAiDesc = () => {
-    setAiDesc("AI Suggestion: Collaborate on a tech review series with cross-promotion and audience Q&A.");
+    setAiDesc(
+      "AI Suggestion: Collaborate on a tech review series with cross-promotion and audience Q&A."
+    );
   };
 
   const handleAiProposal = () => {
@@ -52,7 +58,7 @@ export default function NewCollaborationModal({ open, onClose, onSubmit }: NewCo
       paymentSchedule: "50% upfront, 50% after delivery",
       numberOfPosts: "2 Instagram posts, 1 YouTube video",
       timeline: "Within 3 weeks of product launch",
-      notes: "Open to creative input and additional deliverables."
+      notes: "Open to creative input and additional deliverables.",
     });
   };
 
@@ -63,7 +69,13 @@ export default function NewCollaborationModal({ open, onClose, onSubmit }: NewCo
     setShowProfile(false);
     setCollabDesc("");
     setAiDesc("");
-    setProposal({ contentLength: "", paymentSchedule: "", numberOfPosts: "", timeline: "", notes: "" });
+    setProposal({
+      contentLength: "",
+      paymentSchedule: "",
+      numberOfPosts: "",
+      timeline: "",
+      notes: "",
+    });
     setAiProposal(null);
     setReviewed(false);
     onClose();
@@ -77,7 +89,7 @@ export default function NewCollaborationModal({ open, onClose, onSubmit }: NewCo
           creator: selectedCreator,
           description: collabDesc || aiDesc,
           proposal,
-          reviewed: true
+          reviewed: true,
         });
       }
       handleResetModal();
@@ -86,48 +98,92 @@ export default function NewCollaborationModal({ open, onClose, onSubmit }: NewCo
 
   return (
     <>
-      <Dialog open={open} onOpenChange={(v) => { if (!v) handleResetModal(); }}>
+      <Dialog
+        open={open}
+        onOpenChange={(v) => {
+          if (!v) handleResetModal();
+        }}
+      >
         <DialogContent className="max-w-2xl w-full">
           <DialogHeader>
             <DialogTitle>New Collaboration Request</DialogTitle>
           </DialogHeader>
-          
+
           {/* Stepper */}
           <div className="flex justify-between mb-4 text-xs">
-            <div className={`font-bold ${modalStep === 1 ? 'text-purple-700' : 'text-gray-400'}`}>1. Search Creator</div>
-            <div className={`font-bold ${modalStep === 2 ? 'text-purple-700' : 'text-gray-400'}`}>2. Describe Collab</div>
-            <div className={`font-bold ${modalStep === 3 ? 'text-purple-700' : 'text-gray-400'}`}>3. Proposal Details</div>
-            <div className={`font-bold ${modalStep === 4 ? 'text-purple-700' : 'text-gray-400'}`}>4. Review & Send</div>
+            <div
+              className={`font-bold ${
+                modalStep === 1 ? "text-purple-700" : "text-gray-400"
+              }`}
+            >
+              1. Search Creator
+            </div>
+            <div
+              className={`font-bold ${
+                modalStep === 2 ? "text-purple-700" : "text-gray-400"
+              }`}
+            >
+              2. Describe Collab
+            </div>
+            <div
+              className={`font-bold ${
+                modalStep === 3 ? "text-purple-700" : "text-gray-400"
+              }`}
+            >
+              3. Proposal Details
+            </div>
+            <div
+              className={`font-bold ${
+                modalStep === 4 ? "text-purple-700" : "text-gray-400"
+              }`}
+            >
+              4. Review & Send
+            </div>
           </div>
 
           {/* Step 1: Search Creator */}
           {modalStep === 1 && (
             <div>
-              <Input 
-                placeholder="Search creators by name..." 
-                value={searchTerm} 
-                onChange={e => setSearchTerm(e.target.value)} 
-                className="mb-4" 
+              <Input
+                placeholder="Search creators by name..."
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+                className="mb-4"
               />
               {searchResults.length > 0 ? (
                 <div className="flex flex-col gap-4">
                   {searchResults.map((creator, idx) => (
-                    <Card key={idx} className={`border-2 ${selectedCreator?.id === creator.id ? 'border-purple-500' : 'border-gray-200'}`}>
+                    <Card
+                      key={idx}
+                      className={`border-2 ${
+                        selectedCreator?.id === creator.id
+                          ? "border-purple-500"
+                          : "border-gray-200"
+                      }`}
+                    >
                       <CardContent className="flex items-center gap-4">
                         <div className="flex-1">
-                          <div className="font-bold text-lg">{creator.name}</div>
-                          <div className="text-sm text-gray-500">{creator.contentType} • {creator.location}</div>
+                          <div className="font-bold text-lg">
+                            {creator.name}
+                          </div>
+                          <div className="text-sm text-gray-500">
+                            {creator.contentType} • {creator.location}
+                          </div>
                         </div>
-                        <Button 
-                          size="sm" 
-                          variant="outline" 
-                          onClick={() => { setSelectedCreator(creator); setShowProfile(true); }}
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() => {
+                            onClose(); 
+                            setSelectedCreator(creator);
+                            setShowProfile(true);
+                          }}
                         >
                           View Profile
                         </Button>
-                        <Button 
-                          size="sm" 
-                          className="bg-purple-600 text-white" 
+                        <Button
+                          size="sm"
+                          className="bg-purple-600 text-white"
                           onClick={() => setSelectedCreator(creator)}
                         >
                           Select
@@ -137,13 +193,17 @@ export default function NewCollaborationModal({ open, onClose, onSubmit }: NewCo
                   ))}
                 </div>
               ) : (
-                <div className="text-gray-400 text-center py-8">Type a name to search for creators.</div>
+                <div className="text-gray-400 text-center py-8">
+                  Type a name to search for creators.
+                </div>
               )}
               <div className="flex justify-end mt-6 gap-2">
-                <Button variant="outline" onClick={handleResetModal}>Cancel</Button>
-                <Button 
-                  disabled={!selectedCreator} 
-                  className="bg-purple-600 text-white" 
+                <Button variant="outline" onClick={handleResetModal}>
+                  Cancel
+                </Button>
+                <Button
+                  disabled={!selectedCreator}
+                  className="bg-purple-600 text-white"
                   onClick={() => setModalStep(2)}
                 >
                   Next
@@ -155,15 +215,21 @@ export default function NewCollaborationModal({ open, onClose, onSubmit }: NewCo
           {/* Step 2: Describe Collab */}
           {modalStep === 2 && (
             <div>
-              <div className="mb-2 font-semibold">Describe the collaboration you're looking for</div>
-              <Textarea 
-                placeholder="Describe your ideal collaboration..." 
-                value={collabDesc} 
-                onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setCollabDesc(e.target.value)} 
-                rows={3} 
+              <div className="mb-2 font-semibold">
+                Describe the collaboration you're looking for
+              </div>
+              <Textarea
+                placeholder="Describe your ideal collaboration..."
+                value={collabDesc}
+                onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+                  setCollabDesc(e.target.value)
+                }
+                rows={3}
               />
               <div className="flex gap-2 mt-2">
-                <Button size="sm" variant="outline" onClick={handleAiDesc}>AI Suggest</Button>
+                <Button size="sm" variant="outline" onClick={handleAiDesc}>
+                  AI Suggest
+                </Button>
                 {aiDesc && (
                   <div className="bg-blue-50 text-blue-800 px-3 py-2 rounded text-xs flex-1">
                     {aiDesc}
@@ -171,11 +237,15 @@ export default function NewCollaborationModal({ open, onClose, onSubmit }: NewCo
                 )}
               </div>
               <div className="flex justify-between mt-6 gap-2">
-                <Button variant="outline" onClick={handleResetModal}>Cancel</Button>
-                <Button variant="outline" onClick={() => setModalStep(1)}>Back</Button>
-                <Button 
-                  className="bg-purple-600 text-white" 
-                  onClick={() => setModalStep(3)} 
+                <Button variant="outline" onClick={handleResetModal}>
+                  Cancel
+                </Button>
+                <Button variant="outline" onClick={() => setModalStep(1)}>
+                  Back
+                </Button>
+                <Button
+                  className="bg-purple-600 text-white"
+                  onClick={() => setModalStep(3)}
                   disabled={!collabDesc && !aiDesc}
                 >
                   Next
@@ -189,46 +259,63 @@ export default function NewCollaborationModal({ open, onClose, onSubmit }: NewCo
             <div>
               <div className="mb-2 font-semibold">Proposal Details</div>
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <Input 
-                  placeholder="Content Length (e.g. 5-7 min video)" 
-                  value={proposal.contentLength} 
-                  onChange={e => setProposal({ ...proposal, contentLength: e.target.value })} 
+                <Input
+                  placeholder="Content Length (e.g. 5-7 min video)"
+                  value={proposal.contentLength}
+                  onChange={(e) =>
+                    setProposal({ ...proposal, contentLength: e.target.value })
+                  }
                 />
-                <Input 
-                  placeholder="Payment Schedule (e.g. 50% upfront)" 
-                  value={proposal.paymentSchedule} 
-                  onChange={e => setProposal({ ...proposal, paymentSchedule: e.target.value })} 
+                <Input
+                  placeholder="Payment Schedule (e.g. 50% upfront)"
+                  value={proposal.paymentSchedule}
+                  onChange={(e) =>
+                    setProposal({
+                      ...proposal,
+                      paymentSchedule: e.target.value,
+                    })
+                  }
                 />
-                <Input 
-                  placeholder="Number of Posts (e.g. 2 IG posts)" 
-                  value={proposal.numberOfPosts} 
-                  onChange={e => setProposal({ ...proposal, numberOfPosts: e.target.value })} 
+                <Input
+                  placeholder="Number of Posts (e.g. 2 IG posts)"
+                  value={proposal.numberOfPosts}
+                  onChange={(e) =>
+                    setProposal({ ...proposal, numberOfPosts: e.target.value })
+                  }
                 />
-                <Input 
-                  placeholder="Timeline (e.g. 3 weeks)" 
-                  value={proposal.timeline} 
-                  onChange={e => setProposal({ ...proposal, timeline: e.target.value })} 
+                <Input
+                  placeholder="Timeline (e.g. 3 weeks)"
+                  value={proposal.timeline}
+                  onChange={(e) =>
+                    setProposal({ ...proposal, timeline: e.target.value })
+                  }
                 />
               </div>
-              <Textarea 
-                placeholder="Additional Notes" 
-                value={proposal.notes} 
-                onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setProposal({ ...proposal, notes: e.target.value })} 
-                className="mt-2" 
+              <Textarea
+                placeholder="Additional Notes"
+                value={proposal.notes}
+                onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+                  setProposal({ ...proposal, notes: e.target.value })
+                }
+                className="mt-2"
               />
               <div className="flex gap-2 mt-2">
-                <Button size="sm" variant="outline" onClick={handleAiProposal}>AI Draft Proposal</Button>
+                <Button size="sm" variant="outline" onClick={handleAiProposal}>
+                  AI Draft Proposal
+                </Button>
                 {aiProposal && (
                   <div className="bg-green-50 text-green-800 px-3 py-2 rounded text-xs flex-1">
-                    <div><b>AI Proposal:</b></div>
+                    <div>
+                      <b>AI Proposal:</b>
+                    </div>
                     <div>Content Length: {aiProposal.contentLength}</div>
                     <div>Payment: {aiProposal.paymentSchedule}</div>
                     <div>Posts: {aiProposal.numberOfPosts}</div>
                     <div>Timeline: {aiProposal.timeline}</div>
                     <div>Notes: {aiProposal.notes}</div>
-                    <Button 
-                      size="sm" 
-                      className="mt-1 bg-green-200 text-green-900" 
+                    <Button
+                      size="sm"
+                      className="mt-1 bg-green-200 text-green-900"
                       onClick={() => setProposal(aiProposal)}
                     >
                       Use This
@@ -237,12 +324,21 @@ export default function NewCollaborationModal({ open, onClose, onSubmit }: NewCo
                 )}
               </div>
               <div className="flex justify-between mt-6 gap-2">
-                <Button variant="outline" onClick={handleResetModal}>Cancel</Button>
-                <Button variant="outline" onClick={() => setModalStep(2)}>Back</Button>
-                <Button 
-                  className="bg-purple-600 text-white" 
-                  onClick={() => setModalStep(4)} 
-                  disabled={!proposal.contentLength || !proposal.paymentSchedule || !proposal.numberOfPosts || !proposal.timeline}
+                <Button variant="outline" onClick={handleResetModal}>
+                  Cancel
+                </Button>
+                <Button variant="outline" onClick={() => setModalStep(2)}>
+                  Back
+                </Button>
+                <Button
+                  className="bg-purple-600 text-white"
+                  onClick={() => setModalStep(4)}
+                  disabled={
+                    !proposal.contentLength ||
+                    !proposal.paymentSchedule ||
+                    !proposal.numberOfPosts ||
+                    !proposal.timeline
+                  }
                 >
                   Next
                 </Button>
@@ -259,34 +355,58 @@ export default function NewCollaborationModal({ open, onClose, onSubmit }: NewCo
                   <CardTitle>To: {selectedCreator?.name}</CardTitle>
                 </CardHeader>
                 <CardContent>
-                  <div className="mb-2"><b>Description:</b> {collabDesc || aiDesc}</div>
-                  <div className="mb-2"><b>Content Length:</b> {proposal.contentLength}</div>
-                  <div className="mb-2"><b>Payment Schedule:</b> {proposal.paymentSchedule}</div>
-                  <div className="mb-2"><b>Number of Posts:</b> {proposal.numberOfPosts}</div>
-                  <div className="mb-2"><b>Timeline:</b> {proposal.timeline}</div>
-                  <div className="mb-2"><b>Notes:</b> {proposal.notes}</div>
+                  <div className="mb-2">
+                    <b>Description:</b> {collabDesc || aiDesc}
+                  </div>
+                  <div className="mb-2">
+                    <b>Content Length:</b> {proposal.contentLength}
+                  </div>
+                  <div className="mb-2">
+                    <b>Payment Schedule:</b> {proposal.paymentSchedule}
+                  </div>
+                  <div className="mb-2">
+                    <b>Number of Posts:</b> {proposal.numberOfPosts}
+                  </div>
+                  <div className="mb-2">
+                    <b>Timeline:</b> {proposal.timeline}
+                  </div>
+                  <div className="mb-2">
+                    <b>Notes:</b> {proposal.notes}
+                  </div>
                 </CardContent>
               </Card>
               <div className="flex justify-between mt-6 gap-2">
-                <Button variant="outline" onClick={handleResetModal}>Cancel</Button>
-                <Button variant="outline" onClick={() => setModalStep(3)}>Back</Button>
-                <Button className="bg-green-600 text-white" onClick={handleSubmit}>
+                <Button variant="outline" onClick={handleResetModal}>
+                  Cancel
+                </Button>
+                <Button variant="outline" onClick={() => setModalStep(3)}>
+                  Back
+                </Button>
+                <Button
+                  className="bg-green-600 text-white"
+                  onClick={handleSubmit}
+                >
                   Send Request
                 </Button>
               </div>
               {reviewed && (
-                <div className="text-green-700 text-center mt-4 font-semibold">Request Sent!</div>
+                <div className="text-green-700 text-center mt-4 font-semibold">
+                  Request Sent!
+                </div>
               )}
             </div>
           )}
         </DialogContent>
       </Dialog>
 
-      <ViewProfileModal 
-        open={showProfile} 
-        onClose={() => setShowProfile(false)} 
-        onConnect={() => { setShowProfile(false); setSelectedCreator(searchResults[0]); }} 
+      <ViewProfileModal
+        open={showProfile}
+        onClose={() => setShowProfile(false)}
+        onConnect={() => {
+          setShowProfile(false);
+          setSelectedCreator(searchResults[0]);
+        }}
       />
     </>
   );
-} 
+}


### PR DESCRIPTION
###Fixes
 #132 – Search result “View Profile” is hidden behind collaboration Dialog  .

###Description

This PR fixes the issue where the "View Profile" modal was appearing behind the Collaboration modal and also allowed click-through, causing unexpected behaviour.

###This PR ensures

1. Parent modal closes before opening View Profile modal

2. Prevents click-through and focus leakage

3. Provides consistent modal behaviour across collaboration flow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed modal closure sequencing when viewing creator profiles—modal now properly closes before opening the profile view.
  * Improved connection flow to automatically select the first search result when connecting to a creator.

* **Refactor**
  * Adjusted UI element spacing and structure for consistency.
  * Optimized modal interaction behavior for improved user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->