### PR TITLE
docs: document VS Code TypeScript version mismatch for - DOCS UPDATE: #247

### DIFF
--- a/Frontend/README.md
+++ b/Frontend/README.md
@@ -7,9 +7,28 @@ Currently, two official plugins are available:
 - [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh
 - [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
 
-## Expanding the ESLint configuration
+---
 
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
+## ⚠️ VS Code TypeScript Version Notice
+
+This project uses **TypeScript 5.5+** features.  
+VS Code may default to its bundled TypeScript version (for example, 5.2), which can cause
+false-positive TypeScript configuration errors in the editor, even though the project builds
+and runs correctly.
+
+### Fix: Use Workspace TypeScript Version
+
+To ensure VS Code uses the project’s local TypeScript version:
+
+1. Open any `.ts` or `.tsx` file
+2. Press `Ctrl + Shift + P`
+3. Select **Preferences: Open Workspace Settings (JSON)**
+4. Add the following configuration:
+   ```json
+   {
+     "typescript.tsdk": "node_modules/typescript/lib"
+   }
+
 
 ```js
 export default tseslint.config({
@@ -29,6 +48,7 @@ export default tseslint.config({
     },
   },
 })
+
 ```
 
 You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

## 📝 Description

This pull request updates the project documentation to address a common VS Code
tooling issue where the editor uses an older bundled TypeScript version, resulting
in false-positive `tsconfig` errors even though the project builds correctly.

The README now clearly explains the issue and provides a workspace-level fix to
ensure VS Code uses the project’s local TypeScript version.

---

## 🔧 Changes Made

- Added a VS Code TypeScript version notice to the README
- Documented the workspace configuration required to fix the mismatch
- Improved developer setup clarity for new contributors

---

## 📷 Screenshots or Visual Changes (if applicable)

Not applicable — documentation-only changes.

---

## 🤝 Collaboration

Collaborated with: *(none)*

---

### ✅ Checklist

- [x] I have read the contributing guidelines.
- [ ] I have added tests that prove my fix is effective or that my feature works.  
  *(Not applicable — documentation-only change)*
- [x] I have added necessary documentation (if applicable).
- [x] Any dependent changes have been merged and published in downstream modules.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with TypeScript version compatibility notes for VS Code environments.
  * Added step-by-step configuration guidance to resolve TypeScript version conflicts in the editor.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->