### PR TITLE
Fix: Force IPv4 in Vite proxy to resolve Windows ::1 ECONNREFUSED error

### DIFF
--- a/Frontend/vite.config.ts
+++ b/Frontend/vite.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
   },
   server: {
     proxy: {
-      '/api': 'http://localhost:8000',
+      '/api': 'http://127.0.0.1:8000',
     },
   },
 });


### PR DESCRIPTION
Description
I encountered a network connection error on Windows where the frontend could not communicate with the backend, resulting in the error: Error: connect ECONNREFUSED ::1:8000.

This happens because localhost often resolves to IPv6 (::1) on Windows, but the Python backend listens on IPv4 (127.0.0.1). This PR fixes the vite.config.ts proxy settings to explicitly use the IPv4 address, ensuring consistent connectivity.

Changes Made
Config: Updated Frontend/vite.config.ts proxy target from http://localhost:8000 to http://127.0.0.1:8000.

📷 Screenshots or Visual Changes (if applicable)
Terminal: The error http proxy error: /api/trending-niches no longer appears in the logs.
before fix:
<img width="1539" height="972" alt="Screenshot 2025-12-30 130158" src="https://github.com/user-attachments/assets/76f6b2d8-ff4a-4372-a917-c67a1a296f89" />

After Fix:
<img width="1500" height="964" alt="image" src="https://github.com/user-attachments/assets/e7a306eb-0d9b-4242-9613-1063c870bdc9" />


App: The frontend can now successfully fetch data from the backend API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development server configuration for API request routing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->