### PR TITLE
Fix signup auth switch placement inside card

### DIFF
--- a/Frontend/src/pages/Signup.tsx
+++ b/Frontend/src/pages/Signup.tsx
@@ -129,23 +129,23 @@ export default function SignupPage() {
             Inpact
           </span>
         </Link>
-        <div className="flex space-x-4">
-          <span className="text-sm text-gray-600 dark:text-gray-300">
-            Already have an account?
-          </span>
-          <Link
-            to="/login"
-            className="text-sm font-medium text-purple-600 hover:text-purple-800 dark:text-purple-400 dark:hover:text-purple-300 transition-colors duration-200"
-          >
-            Sign in
-          </Link>
-        </div>
+       
       </div>
 
       <div className="flex-1 flex items-center justify-center p-6">
         <div className="w-full max-w-md">
           <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-xl overflow-hidden transform transition-all duration-300 hover:shadow-2xl">
             <div className="p-8">
+              <div className="mt-6 text-center text-sm text-gray-600 dark:text-gray-300">
+  Already have an account?{" "}
+  <Link
+    to="/login"
+    className="font-medium text-purple-600 hover:text-purple-800 dark:text-purple-400 dark:hover:text-purple-300 transition-colors duration-200"
+  >
+    Sign in
+  </Link>
+</div>
+
               <h2 className="text-3xl font-bold text-gray-900 dark:text-white mb-2">
                 {step === 1 ? "Create your account" : "Complete your profile"}
               </h2>


### PR DESCRIPTION
Closes #264

Description
This PR fixes a UI inconsistency on the signup page by moving the
“Already have an account? Sign in” link inside the signup card.

This improves visual consistency, UX, and aligns the signup layout
with common authentication design patterns.

Changes Made
- Moved the auth switch text inside the signup card
- Kept header clean and focused on branding
- No functional or logic changes

Screenshot
After:

<img width="1895" height="914" alt="Screenshot 2026-01-08 202139" src="https://github.com/user-attachments/assets/173601cd-8763-4ad1-b148-5c4d7e3c97fa" />


-  I have tested this change locally
- This PR makes a focused UI improvement




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced the signup page layout by relocating the sign-in link from the header area directly into the signup card for improved visual flow and user experience. Refined typography weight and alignment styling to maintain visual consistency and improve overall clarity within the signup form interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->