### PR TITLE
feat: Add API Pagination to Backend List Endpoints

### DIFF
--- a/Backend/app/routes/post.py
+++ b/Backend/app/routes/post.py
@@ -61,8 +61,10 @@ async def get_users(
     start = skip
     end = skip + limit - 1
     
-    result = supabase.table("users").select("*").range(start, end).execute()
-    return paginate_query(result, skip, limit)
+    result = supabase.table("users").select("*").order("id").range(start, end).execute()
+    count_result = supabase.table("users").select("*", count="exact").execute()
+    total_count = count_result.count if hasattr(count_result, 'count') else len(count_result.data)
+    return paginate_query(result, skip, limit, total_count)
 
 # ========== AUDIENCE INSIGHTS ROUTES ==========
 @router.post("/audience-insights/")
@@ -93,8 +95,10 @@ async def get_audience_insights(
     start = skip
     end = skip + limit - 1
     
-    result = supabase.table("audience_insights").select("*").range(start, end).execute()
-    return paginate_query(result, skip, limit)
+    result = supabase.table("audience_insights").select("*").order("id").range(start, end).execute()
+    count_result = supabase.table("audience_insights").select("*", count="exact").execute()
+    total_count = count_result.count if hasattr(count_result, 'count') else len(count_result.data)
+    return paginate_query(result, skip, limit, total_count)
 
 # ========== SPONSORSHIP ROUTES ==========
 @router.post("/sponsorships/")
@@ -125,8 +129,10 @@ async def get_sponsorships(
     start = skip
     end = skip + limit - 1
     
-    result = supabase.table("sponsorships").select("*").range(start, end).execute()
-    return paginate_query(result, skip, limit)
+    result = supabase.table("sponsorships").select("*").order("id").range(start, end).execute()
+    count_result = supabase.table("sponsorships").select("*", count="exact").execute()
+    total_count = count_result.count if hasattr(count_result, 'count') else len(count_result.data)
+    return paginate_query(result, skip, limit, total_count)
 
 # ========== USER POST ROUTES ==========
 @router.post("/posts/")
@@ -156,8 +162,10 @@ async def get_posts(
     start = skip
     end = skip + limit - 1
     
-    result = supabase.table("user_posts").select("*").range(start, end).execute()
-    return paginate_query(result, skip, limit)
+    result = supabase.table("user_posts").select("*").order("id").range(start, end).execute()
+    count_result = supabase.table("user_posts").select("*", count="exact").execute()
+    total_count = count_result.count if hasattr(count_result, 'count') else len(count_result.data)
+    return paginate_query(result, skip, limit, total_count)
 
 # ========== SPONSORSHIP APPLICATION ROUTES ==========
 @router.post("/sponsorship-applications/")
@@ -186,8 +194,10 @@ async def get_sponsorship_applications(
     start = skip
     end = skip + limit - 1
     
-    result = supabase.table("sponsorship_applications").select("*").range(start, end).execute()
-    return paginate_query(result, skip, limit)
+    result = supabase.table("sponsorship_applications").select("*").order("id").range(start, end).execute()
+    count_result = supabase.table("sponsorship_applications").select("*", count="exact").execute()
+    total_count = count_result.count if hasattr(count_result, 'count') else len(count_result.data)
+    return paginate_query(result, skip, limit, total_count)
 
 # ========== SPONSORSHIP PAYMENT ROUTES ==========
 @router.post("/sponsorship-payments/")
@@ -215,8 +225,10 @@ async def get_sponsorship_payments(
     start = skip
     end = skip + limit - 1
     
-    result = supabase.table("sponsorship_payments").select("*").range(start, end).execute()
-    return paginate_query(result, skip, limit)
+    result = supabase.table("sponsorship_payments").select("*").order("id").range(start, end).execute()
+    count_result = supabase.table("sponsorship_payments").select("*", count="exact").execute()
+    total_count = count_result.count if hasattr(count_result, 'count') else len(count_result.data)
+    return paginate_query(result, skip, limit, total_count)
 
 # ========== COLLABORATION ROUTES ==========
 @router.post("/collaborations/")
@@ -244,5 +256,7 @@ async def get_collaborations(
     start = skip
     end = skip + limit - 1
     
-    result = supabase.table("collaborations").select("*").range(start, end).execute()
-    return paginate_query(result, skip, limit)
+    result = supabase.table("collaborations").select("*").order("id").range(start, end).execute()
+    count_result = supabase.table("collaborations").select("*", count="exact").execute()
+    total_count = count_result.count if hasattr(count_result, 'count') else len(count_result.data)
+    return paginate_query(result, skip, limit, total_count)

--- a/Backend/app/routes/post.py
+++ b/Backend/app/routes/post.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
 from ..db.db import AsyncSessionLocal
@@ -10,8 +10,8 @@ from ..schemas.schema import (
     UserCreate, AudienceInsightsCreate, SponsorshipCreate, UserPostCreate,
     SponsorshipApplicationCreate, SponsorshipPaymentCreate, CollaborationCreate
 )
+from ..utils.pagination import get_pagination_params, paginate_query
 
-from fastapi import APIRouter, HTTPException
 import os
 from supabase import create_client, Client
 from dotenv import load_dotenv
@@ -53,9 +53,16 @@ async def create_user(user: UserCreate):
     return response
 
 @router.get("/users/")
-async def get_users():
-    result = supabase.table("users").select("*").execute()
-    return result
+async def get_users(
+    skip: int = Query(0, ge=0, description="Number of records to skip"),
+    limit: int = Query(50, ge=1, le=100, description="Maximum number of records to return")
+):
+    skip, limit = get_pagination_params(skip, limit)
+    start = skip
+    end = skip + limit - 1
+    
+    result = supabase.table("users").select("*").range(start, end).execute()
+    return paginate_query(result, skip, limit)
 
 # ========== AUDIENCE INSIGHTS ROUTES ==========
 @router.post("/audience-insights/")
@@ -78,9 +85,16 @@ async def create_audience_insights(insights: AudienceInsightsCreate):
     return response
 
 @router.get("/audience-insights/")
-async def get_audience_insights():
-    result = supabase.table("audience_insights").select("*").execute()
-    return result
+async def get_audience_insights(
+    skip: int = Query(0, ge=0, description="Number of records to skip"),
+    limit: int = Query(50, ge=1, le=100, description="Maximum number of records to return")
+):
+    skip, limit = get_pagination_params(skip, limit)
+    start = skip
+    end = skip + limit - 1
+    
+    result = supabase.table("audience_insights").select("*").range(start, end).execute()
+    return paginate_query(result, skip, limit)
 
 # ========== SPONSORSHIP ROUTES ==========
 @router.post("/sponsorships/")
@@ -103,9 +117,16 @@ async def create_sponsorship(sponsorship: SponsorshipCreate):
     return response
 
 @router.get("/sponsorships/")
-async def get_sponsorships():
-    result = supabase.table("sponsorships").select("*").execute()
-    return result
+async def get_sponsorships(
+    skip: int = Query(0, ge=0, description="Number of records to skip"),
+    limit: int = Query(50, ge=1, le=100, description="Maximum number of records to return")
+):
+    skip, limit = get_pagination_params(skip, limit)
+    start = skip
+    end = skip + limit - 1
+    
+    result = supabase.table("sponsorships").select("*").range(start, end).execute()
+    return paginate_query(result, skip, limit)
 
 # ========== USER POST ROUTES ==========
 @router.post("/posts/")
@@ -127,9 +148,16 @@ async def create_post(post: UserPostCreate):
     return response
 
 @router.get("/posts/")
-async def get_posts():
-    result = supabase.table("user_posts").select("*").execute()
-    return result
+async def get_posts(
+    skip: int = Query(0, ge=0, description="Number of records to skip"),
+    limit: int = Query(50, ge=1, le=100, description="Maximum number of records to return")
+):
+    skip, limit = get_pagination_params(skip, limit)
+    start = skip
+    end = skip + limit - 1
+    
+    result = supabase.table("user_posts").select("*").range(start, end).execute()
+    return paginate_query(result, skip, limit)
 
 # ========== SPONSORSHIP APPLICATION ROUTES ==========
 @router.post("/sponsorship-applications/")
@@ -150,9 +178,16 @@ async def create_sponsorship_application(application: SponsorshipApplicationCrea
     return response
 
 @router.get("/sponsorship-applications/")
-async def get_sponsorship_applications():
-    result = supabase.table("sponsorship_applications").select("*").execute()
-    return result
+async def get_sponsorship_applications(
+    skip: int = Query(0, ge=0, description="Number of records to skip"),
+    limit: int = Query(50, ge=1, le=100, description="Maximum number of records to return")
+):
+    skip, limit = get_pagination_params(skip, limit)
+    start = skip
+    end = skip + limit - 1
+    
+    result = supabase.table("sponsorship_applications").select("*").range(start, end).execute()
+    return paginate_query(result, skip, limit)
 
 # ========== SPONSORSHIP PAYMENT ROUTES ==========
 @router.post("/sponsorship-payments/")
@@ -172,9 +207,16 @@ async def create_sponsorship_payment(payment: SponsorshipPaymentCreate):
     return response
 
 @router.get("/sponsorship-payments/")
-async def get_sponsorship_payments():
-    result = supabase.table("sponsorship_payments").select("*").execute()
-    return result
+async def get_sponsorship_payments(
+    skip: int = Query(0, ge=0, description="Number of records to skip"),
+    limit: int = Query(50, ge=1, le=100, description="Maximum number of records to return")
+):
+    skip, limit = get_pagination_params(skip, limit)
+    start = skip
+    end = skip + limit - 1
+    
+    result = supabase.table("sponsorship_payments").select("*").range(start, end).execute()
+    return paginate_query(result, skip, limit)
 
 # ========== COLLABORATION ROUTES ==========
 @router.post("/collaborations/")
@@ -194,6 +236,13 @@ async def create_collaboration(collab: CollaborationCreate):
     return response
 
 @router.get("/collaborations/")
-async def get_collaborations():
-    result = supabase.table("collaborations").select("*").execute()
-    return result
+async def get_collaborations(
+    skip: int = Query(0, ge=0, description="Number of records to skip"),
+    limit: int = Query(50, ge=1, le=100, description="Maximum number of records to return")
+):
+    skip, limit = get_pagination_params(skip, limit)
+    start = skip
+    end = skip + limit - 1
+    
+    result = supabase.table("collaborations").select("*").range(start, end).execute()
+    return paginate_query(result, skip, limit)

--- a/Backend/app/routes/post.py
+++ b/Backend/app/routes/post.py
@@ -62,7 +62,7 @@ async def get_users(
     end = skip + limit - 1
     
     result = supabase.table("users").select("*").order("id").range(start, end).execute()
-    count_result = supabase.table("users").select("*", count="exact").execute()
+    count_result = supabase.table("users").select("*", count="exact").limit(0).execute()
     total_count = count_result.count if hasattr(count_result, 'count') else len(count_result.data)
     return paginate_query(result, skip, limit, total_count)
 
@@ -96,7 +96,7 @@ async def get_audience_insights(
     end = skip + limit - 1
     
     result = supabase.table("audience_insights").select("*").order("id").range(start, end).execute()
-    count_result = supabase.table("audience_insights").select("*", count="exact").execute()
+    count_result = supabase.table("audience_insights").select("*", count="exact").limit(0).execute()
     total_count = count_result.count if hasattr(count_result, 'count') else len(count_result.data)
     return paginate_query(result, skip, limit, total_count)
 
@@ -130,7 +130,7 @@ async def get_sponsorships(
     end = skip + limit - 1
     
     result = supabase.table("sponsorships").select("*").order("id").range(start, end).execute()
-    count_result = supabase.table("sponsorships").select("*", count="exact").execute()
+    count_result = supabase.table("sponsorships").select("*", count="exact").limit(0).execute()
     total_count = count_result.count if hasattr(count_result, 'count') else len(count_result.data)
     return paginate_query(result, skip, limit, total_count)
 
@@ -163,7 +163,7 @@ async def get_posts(
     end = skip + limit - 1
     
     result = supabase.table("user_posts").select("*").order("id").range(start, end).execute()
-    count_result = supabase.table("user_posts").select("*", count="exact").execute()
+    count_result = supabase.table("user_posts").select("*", count="exact").limit(0).execute()
     total_count = count_result.count if hasattr(count_result, 'count') else len(count_result.data)
     return paginate_query(result, skip, limit, total_count)
 
@@ -195,7 +195,7 @@ async def get_sponsorship_applications(
     end = skip + limit - 1
     
     result = supabase.table("sponsorship_applications").select("*").order("id").range(start, end).execute()
-    count_result = supabase.table("sponsorship_applications").select("*", count="exact").execute()
+    count_result = supabase.table("sponsorship_applications").select("*", count="exact").limit(0).execute()
     total_count = count_result.count if hasattr(count_result, 'count') else len(count_result.data)
     return paginate_query(result, skip, limit, total_count)
 
@@ -226,7 +226,7 @@ async def get_sponsorship_payments(
     end = skip + limit - 1
     
     result = supabase.table("sponsorship_payments").select("*").order("id").range(start, end).execute()
-    count_result = supabase.table("sponsorship_payments").select("*", count="exact").execute()
+    count_result = supabase.table("sponsorship_payments").select("*", count="exact").limit(0).execute()
     total_count = count_result.count if hasattr(count_result, 'count') else len(count_result.data)
     return paginate_query(result, skip, limit, total_count)
 
@@ -257,6 +257,6 @@ async def get_collaborations(
     end = skip + limit - 1
     
     result = supabase.table("collaborations").select("*").order("id").range(start, end).execute()
-    count_result = supabase.table("collaborations").select("*", count="exact").execute()
+    count_result = supabase.table("collaborations").select("*", count="exact").limit(0).execute()
     total_count = count_result.count if hasattr(count_result, 'count') else len(count_result.data)
     return paginate_query(result, skip, limit, total_count)

--- a/Backend/app/utils/pagination.py
+++ b/Backend/app/utils/pagination.py
@@ -17,7 +17,7 @@ def get_pagination_params(skip: int = DEFAULT_SKIP, limit: int = DEFAULT_LIMIT) 
     return skip, limit
 
 
-def paginate_query(query_result, skip: int, limit: int) -> Dict[str, Any]:
+def paginate_query(query_result, skip: int, limit: int, total_count: int = 0) -> Dict[str, Any]:
     """Format paginated response with metadata."""
     data = query_result.data if hasattr(query_result, 'data') else query_result
     
@@ -28,5 +28,6 @@ def paginate_query(query_result, skip: int, limit: int) -> Dict[str, Any]:
         "data": data,
         "skip": skip,
         "limit": limit,
-        "count": len(data)
+        "count": len(data),
+        "total_count": total_count
     }

--- a/Backend/app/utils/pagination.py
+++ b/Backend/app/utils/pagination.py
@@ -1,0 +1,32 @@
+from typing import Dict, Any
+
+
+DEFAULT_SKIP = 0
+DEFAULT_LIMIT = 50
+MAX_LIMIT = 100
+
+
+def get_pagination_params(skip: int = DEFAULT_SKIP, limit: int = DEFAULT_LIMIT) -> tuple:
+    """Validate and return pagination parameters."""
+    if skip < 0:
+        skip = DEFAULT_SKIP
+    if limit < 1:
+        limit = DEFAULT_LIMIT
+    if limit > MAX_LIMIT:
+        limit = MAX_LIMIT
+    return skip, limit
+
+
+def paginate_query(query_result, skip: int, limit: int) -> Dict[str, Any]:
+    """Format paginated response with metadata."""
+    data = query_result.data if hasattr(query_result, 'data') else query_result
+    
+    if not isinstance(data, list):
+        data = []
+    
+    return {
+        "data": data,
+        "skip": skip,
+        "limit": limit,
+        "count": len(data)
+    }


### PR DESCRIPTION
## Summary
This PR implements pagination support for all backend list endpoints to prevent performance degradation as the database grows.

## Changes Made
- **New file:** [Backend/app/utils/pagination.py](cci:7://file:///home/nageswara/Desktop/InPactAI/Backend/app/utils/pagination.py:0:0-0:0) - Pagination utility module with parameter validation and response formatting
- **Updated:** [Backend/app/routes/post.py](cci:7://file:///home/nageswara/Desktop/InPactAI/Backend/app/routes/post.py:0:0-0:0) - Added pagination to all 7 GET endpoints:
  - `GET /users/`
  - `GET /audience-insights/`
  - `GET /sponsorships/`
  - `GET /posts/`
  - `GET /sponsorship-applications/`
  - `GET /sponsorship-payments/`
  - `GET /collaborations/`

## Implementation Details

### Query Parameters
All list endpoints now accept:
- `skip` (int, default=0, min=0): Number of records to skip (offset)
- `limit` (int, default=50, min=1, max=100): Maximum records to return per page

### Response Format
Returns paginated response with metadata:
```json
{
  "data": [...],
  "skip": 0,
  "limit": 50,
  "count": 50
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added query-based pagination to all GET endpoints: use skip and limit to navigate large result sets.
  * Default behavior: skip defaults to 0, limit defaults to 50, and limit is capped (max 100).
  * Paginated responses include metadata: returned data, skip, limit, count (returned items), and total_count.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->